### PR TITLE
Improve Build steps for easier deployment

### DIFF
--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -1,0 +1,45 @@
+name: Publish Docker image
+
+on:
+  push:
+    branches: ['main']
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  push_to_registry:
+    name: Push Docker image to ghcr registry
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v3
+
+      - name: Log in to the Github Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch,suffix=_{{sha}}
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push Docker images
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,14 @@
-FROM golang:1.20-alpine
+FROM golang:1.20-alpine AS build
 
 WORKDIR /usr/src/app
 COPY . .
-RUN go build -v -o /usr/local/bin/notification-service ./cmd/notification-service
+# get ssl certs to copy into scratch image, as it won't have them by default.
+RUN apk update && apk add --no-cache git ca-certificates && update-ca-certificates
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -v -o /usr/local/bin/notification-service ./cmd/notification-service
 
-CMD ["notification-service"]
 
+FROM scratch as app
+WORKDIR /
+COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=build /usr/local/bin/notification-service /notification-service
+CMD ["/notification-service"]


### PR DESCRIPTION
This is a small PR that revises the Dockerfile for building the image and adds a workflow step for automatically building the image and publishing it to ghcr.io

For the docker file, we move it from a single stage build to a multi-stage build.  The app binary is built within a golang container, but the resulting binary is then copied to a 0 byte scratch container, where it's actually run.  This multi-stage reduces both the complexity and overall size of the image.  In our case, it reduces the size from nearly 1gb to 25mb.

```
⚡ docker image ls 
REPOSITORY         TAG                  IMAGE ID         SIZE                          
notifications      single-stage-build   560913638255    962MB
notifications      multi-stage-build    236419d1944f   24.8MB
```

The pr also introduces a new file to our `.github/workflows` .  This basically follows the example in [the github docs](https://docs.github.com/en/actions/publishing-packages/publishing-docker-images) for publishing to the ghcr.io registry.
