### PR TITLE
add workflow for publishing stable image on tag

### DIFF
--- a/.github/workflows/publish-stable-docker-image.yml
+++ b/.github/workflows/publish-stable-docker-image.yml
@@ -31,7 +31,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
         with:
-          images: cooldracula/rsslay
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=ref,event=tag
             type=raw,event=tag,value=stable

--- a/.github/workflows/publish-stable-docker-image.yml
+++ b/.github/workflows/publish-stable-docker-image.yml
@@ -1,0 +1,45 @@
+name: Publish Stable Docker image with tag
+
+on:
+  push:
+    tags:
+      - 2**-**-**
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  push_to_registries:
+    name: Push Docker image to ghcr registry
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v3
+
+      - name: Log in to the Github Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: cooldracula/rsslay
+          tags: |
+            type=ref,event=tag
+            type=raw,event=tag,value=stable
+
+      - name: Build and push Docker images
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Adds new workflow file matching the structure and flow of existing docker image workflow, but now only running when we push a `date` tagged commit.  Upon this push, the workflow will build a docker image and tag with with the git tag and with `stable`.