### PR TITLE
Extra event kind checks and reduce max event age

### DIFF
--- a/service/app/downloader.go
+++ b/service/app/downloader.go
@@ -20,7 +20,7 @@ const (
 	reconnectEvery           = 1 * time.Minute
 	manageSubscriptionsEvery = 1 * time.Minute
 
-	howFarIntoThePastToLook = 7 * 24 * time.Hour
+	howFarIntoThePastToLook = 24 * time.Hour
 
 	storeMetricsEvery = 10 * time.Second
 )

--- a/service/domain/event_kind.go
+++ b/service/domain/event_kind.go
@@ -1,6 +1,19 @@
 package domain
 
-import "github.com/boreq/errors"
+import (
+	"github.com/boreq/errors"
+	"github.com/planetary-social/go-notification-service/internal"
+)
+
+var eventKindsToDownload = internal.NewSet([]EventKind{EventKindNote})
+
+func EventKindsToDownload() []EventKind {
+	return eventKindsToDownload.List()
+}
+
+func ShouldDownloadEventKind(eventKind EventKind) bool {
+	return eventKindsToDownload.Contains(eventKind)
+}
 
 var (
 	EventKindNote                   = MustNewEventKind(1)


### PR DESCRIPTION
We made this decision with Matt after seeing high Firestore usage due to saving contact lists with a ton of p tags in them as other events are not supported in the app anyway.