### PR TITLE
Fix Firestore requests are too large when saving tags

### DIFF
--- a/service/app/handler_process_saved_event.go
+++ b/service/app/handler_process_saved_event.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	tagBatchSize       = 150
+	tagBatchSize       = 100
 	apnsTokenBatchSize = 500
 )
 


### PR DESCRIPTION
Thanks Google.

    msg="error handling a message"
    error="error calling the handler: error saving tags: transaction error: transaction returned an error: rpc error: code = InvalidArgument desc = Request payload size exceeds the limit: 11534336 bytes."
    name=root.eventSavedSubscriber