### PR TITLE
Don't store full events under tags

### DIFF
--- a/service/app/handler_process_saved_event.go
+++ b/service/app/handler_process_saved_event.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	tagBatchSize       = 100
+	tagBatchSize       = 150
 	apnsTokenBatchSize = 500
 )
 


### PR DESCRIPTION
I wanted to be smart and save on reads but this doesn't work with huge events.

Fixes errors such as:

    rpc error: code = InvalidArgument desc = Request payload size exceeds the limit: 11534336 bytes.