### PR TITLE
Fix metrics not being captured correctly

### DIFF
--- a/service/app/app.go
+++ b/service/app/app.go
@@ -116,10 +116,12 @@ type ReceivedEventSubscriber interface {
 }
 
 type Metrics interface {
-	TrackApplicationCall(handlerName string) ApplicationCall
+	StartApplicationCall(handlerName string) ApplicationCall
 	MeasureRelayDownloadersState(n int, state RelayDownloaderState)
 }
 
 type ApplicationCall interface {
-	End(err error)
+	// End accepts a pointer so that you can defer this call without wrapping it
+	// in an anonymous function
+	End(err *error)
 }

--- a/service/app/handler_get_events.go
+++ b/service/app/handler_get_events.go
@@ -56,7 +56,7 @@ func NewGetEventsHandler(
 }
 
 func (h *GetEventsHandler) Handle(ctx context.Context, filters domain.Filters) <-chan EventOrEOSEOrError {
-	defer h.metrics.TrackApplicationCall("getEvents").End(nil)
+	defer h.metrics.StartApplicationCall("getEvents").End(nil)
 
 	ch := make(chan EventOrEOSEOrError)
 	go h.send(ctx, filters, ch)

--- a/service/app/handler_get_notifications.go
+++ b/service/app/handler_get_notifications.go
@@ -24,7 +24,7 @@ func NewGetNotificationsHandler(
 }
 
 func (h *GetNotificationsHandler) Handle(ctx context.Context, id domain.EventId) (result []notifications.Notification, err error) {
-	defer func() { h.metrics.TrackApplicationCall("getNotifications").End(err) }()
+	defer h.metrics.StartApplicationCall("getNotifications").End(&err)
 
 	if err := h.transactionProvider.Transact(ctx, func(ctx context.Context, adapters Adapters) error {
 		tmp, err := adapters.Events.GetNotifications(ctx, id)

--- a/service/app/handler_get_public_keys.go
+++ b/service/app/handler_get_public_keys.go
@@ -23,7 +23,7 @@ func NewGetPublicKeysHandler(
 }
 
 func (h *GetPublicKeysHandler) Handle(ctx context.Context, relay domain.RelayAddress) (keys []domain.PublicKey, err error) {
-	defer func() { h.metrics.TrackApplicationCall("getPublicKeys").End(err) }()
+	defer h.metrics.StartApplicationCall("getPublicKeys").End(&err)
 
 	var result []domain.PublicKey
 	if err := h.transactionProvider.Transact(ctx, func(ctx context.Context, adapters Adapters) error {

--- a/service/app/handler_get_relays.go
+++ b/service/app/handler_get_relays.go
@@ -23,7 +23,7 @@ func NewGetRelaysHandler(
 }
 
 func (h *GetRelaysHandler) Handle(ctx context.Context) (addresses []domain.RelayAddress, err error) {
-	defer func() { h.metrics.TrackApplicationCall("getRelays").End(err) }()
+	defer h.metrics.StartApplicationCall("getRelays").End(&err)
 
 	var result []domain.RelayAddress
 	if err := h.transactionProvider.Transact(ctx, func(ctx context.Context, adapters Adapters) error {

--- a/service/app/handler_get_tokens.go
+++ b/service/app/handler_get_tokens.go
@@ -23,7 +23,7 @@ func NewGetTokensHandler(
 }
 
 func (h *GetTokensHandler) Handle(ctx context.Context, publicKey domain.PublicKey) (tokens []domain.APNSToken, err error) {
-	defer func() { h.metrics.TrackApplicationCall("getTokens").End(err) }()
+	defer h.metrics.StartApplicationCall("getTokens").End(&err)
 
 	var result []domain.APNSToken
 	if err := h.transactionProvider.Transact(ctx, func(ctx context.Context, adapters Adapters) error {

--- a/service/app/handler_process_saved_event.go
+++ b/service/app/handler_process_saved_event.go
@@ -49,7 +49,7 @@ func NewProcessSavedEventHandler(
 }
 
 func (h *ProcessSavedEventHandler) Handle(ctx context.Context, cmd ProcessSavedEvent) (err error) {
-	defer func() { h.metrics.TrackApplicationCall("processSavedEvent").End(err) }()
+	defer h.metrics.StartApplicationCall("processSavedEvent").End(&err)
 
 	logger := h.logger.WithField("event.id", cmd.eventId.Hex())
 

--- a/service/app/handler_save_received_event.go
+++ b/service/app/handler_save_received_event.go
@@ -37,7 +37,7 @@ func NewSaveReceivedEventHandler(
 }
 
 func (h *SaveReceivedEventHandler) Handle(ctx context.Context, cmd SaveReceivedEvent) (err error) {
-	defer func() { h.metrics.TrackApplicationCall("saveReceivedEvent").End(err) }()
+	defer h.metrics.StartApplicationCall("saveReceivedEvent").End(&err)
 
 	if !domain.ShouldDownloadEventKind(cmd.event.Kind()) {
 		return fmt.Errorf("event '%s' shouldn't have been downloaded", cmd.event.String())

--- a/service/app/handler_save_registration.go
+++ b/service/app/handler_save_registration.go
@@ -34,7 +34,7 @@ func NewSaveRegistrationHandler(
 }
 
 func (h *SaveRegistrationHandler) Handle(ctx context.Context, cmd SaveRegistration) (err error) {
-	defer func() { h.metrics.TrackApplicationCall("saveRegistration").End(err) }()
+	defer h.metrics.StartApplicationCall("saveRegistration").End(&err)
 
 	h.logger.Debug().
 		WithField("apnsToken", cmd.registration.APNSToken().Hex()).


### PR DESCRIPTION
We deferred the entire call in a function which means that the tracking call wasn't being started on function call and instead was being started on anonymous function call.