### PR TITLE
Add cache which avoids querying Firestore if events were already saved

### DIFF
--- a/cmd/notification-service/di/inject_adapters.go
+++ b/cmd/notification-service/di/inject_adapters.go
@@ -8,6 +8,7 @@ import (
 	"github.com/boreq/errors"
 	"github.com/google/wire"
 	"github.com/planetary-social/go-notification-service/internal/logging"
+	"github.com/planetary-social/go-notification-service/service/adapters"
 	"github.com/planetary-social/go-notification-service/service/adapters/apns"
 	"github.com/planetary-social/go-notification-service/service/adapters/firestore"
 	"github.com/planetary-social/go-notification-service/service/adapters/prometheus"
@@ -64,6 +65,9 @@ var adaptersSet = wire.NewSet(
 	prometheus.NewPrometheus,
 	wire.Bind(new(app.Metrics), new(*prometheus.Prometheus)),
 	wire.Bind(new(firestorepubsub.Metrics), new(*prometheus.Prometheus)),
+
+	adapters.NewMemoryEventWasAlreadySavedCache,
+	wire.Bind(new(app.EventWasAlreadySavedCache), new(*adapters.MemoryEventWasAlreadySavedCache)),
 )
 
 var integrationAdaptersSet = wire.NewSet(
@@ -73,6 +77,9 @@ var integrationAdaptersSet = wire.NewSet(
 	prometheus.NewPrometheus,
 	wire.Bind(new(app.Metrics), new(*prometheus.Prometheus)),
 	wire.Bind(new(firestorepubsub.Metrics), new(*prometheus.Prometheus)),
+
+	adapters.NewMemoryEventWasAlreadySavedCache,
+	wire.Bind(new(app.EventWasAlreadySavedCache), new(*adapters.MemoryEventWasAlreadySavedCache)),
 )
 
 func newFirestoreClient(ctx context.Context, config config.Config, logger logging.Logger) (*googlefirestore.Client, func(), error) {

--- a/service/adapters/cache.go
+++ b/service/adapters/cache.go
@@ -1,0 +1,64 @@
+package adapters
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/planetary-social/go-notification-service/service/domain"
+)
+
+const (
+	cacheSavedEventsFor = 60 * time.Minute
+	cleanupEvery        = 5 * time.Minute
+)
+
+type MemoryEventWasAlreadySavedCache struct {
+	cacheLock sync.Mutex
+	cache     map[domain.EventId]time.Time
+}
+
+func NewMemoryEventWasAlreadySavedCache() *MemoryEventWasAlreadySavedCache {
+	return &MemoryEventWasAlreadySavedCache{
+		cache: make(map[domain.EventId]time.Time),
+	}
+}
+
+func (m *MemoryEventWasAlreadySavedCache) Run(ctx context.Context) error {
+	for {
+		m.cleanup()
+
+		select {
+		case <-time.After(cleanupEvery):
+			continue
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+}
+
+func (m *MemoryEventWasAlreadySavedCache) cleanup() {
+	m.cacheLock.Lock()
+	defer m.cacheLock.Unlock()
+
+	for id, timestamp := range m.cache {
+		if time.Since(timestamp) > cacheSavedEventsFor {
+			delete(m.cache, id)
+		}
+	}
+}
+
+func (m *MemoryEventWasAlreadySavedCache) MarkEventAsAlreadySaved(id domain.EventId) {
+	m.cacheLock.Lock()
+	defer m.cacheLock.Unlock()
+
+	m.cache[id] = time.Now()
+}
+
+func (m *MemoryEventWasAlreadySavedCache) EventWasAlreadySaved(id domain.EventId) bool {
+	m.cacheLock.Lock()
+	defer m.cacheLock.Unlock()
+
+	_, ok := m.cache[id]
+	return ok
+}

--- a/service/app/app.go
+++ b/service/app/app.go
@@ -125,3 +125,8 @@ type ApplicationCall interface {
 	// in an anonymous function
 	End(err *error)
 }
+
+type EventWasAlreadySavedCache interface {
+	MarkEventAsAlreadySaved(id domain.EventId)
+	EventWasAlreadySaved(id domain.EventId) bool
+}


### PR DESCRIPTION
This should prevent confusing metrics showing up in Grafana which indicate that the events are being saved and this should also reduce our Firestore usage.