### PR TITLE
Don't send notifications to tokens that weren't updated in the last 6 months

### DIFF
--- a/service/app/app.go
+++ b/service/app/app.go
@@ -27,8 +27,8 @@ type RegistrationRepository interface {
 }
 
 type RelayRepository interface {
-	GetRelays(ctx context.Context) ([]domain.RelayAddress, error)
-	GetPublicKeys(ctx context.Context, address domain.RelayAddress) ([]domain.PublicKey, error)
+	GetRelays(ctx context.Context, updatedAfter time.Time) ([]domain.RelayAddress, error)
+	GetPublicKeys(ctx context.Context, address domain.RelayAddress, updatedAfter time.Time) ([]domain.PublicKey, error)
 }
 
 type PublicKeyRepository interface {

--- a/service/app/app.go
+++ b/service/app/app.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"time"
 
 	"github.com/planetary-social/go-notification-service/service/domain"
 	"github.com/planetary-social/go-notification-service/service/domain/notifications"
@@ -31,7 +32,7 @@ type RelayRepository interface {
 }
 
 type PublicKeyRepository interface {
-	GetAPNSTokens(context.Context, domain.PublicKey) ([]domain.APNSToken, error)
+	GetAPNSTokens(ctx context.Context, publicKey domain.PublicKey, savedAfter time.Time) ([]domain.APNSToken, error)
 }
 
 type EventRepository interface {

--- a/service/app/downloader.go
+++ b/service/app/downloader.go
@@ -18,9 +18,9 @@ const (
 	getRelaysYoungerThan  = 6 * 30 * 24 * time.Hour
 	recheckRelayListEvery = 5 * time.Minute
 
-	reconnectEvery           = 1 * time.Minute
+	reconnectEvery           = 5 * time.Minute
 	getPublicKeysYoungerThan = 6 * 30 * 24 * time.Hour
-	manageSubscriptionsEvery = 1 * time.Minute
+	manageSubscriptionsEvery = 5 * time.Minute
 
 	howFarIntoThePastToLook = 24 * time.Hour
 

--- a/service/app/downloader.go
+++ b/service/app/downloader.go
@@ -15,9 +15,11 @@ import (
 )
 
 const (
-	recheckRelayListEvery = 1 * time.Minute
+	getRelaysYoungerThan  = 6 * 30 * 24 * time.Hour
+	recheckRelayListEvery = 5 * time.Minute
 
 	reconnectEvery           = 1 * time.Minute
+	getPublicKeysYoungerThan = 6 * 30 * 24 * time.Hour
 	manageSubscriptionsEvery = 1 * time.Minute
 
 	howFarIntoThePastToLook = 24 * time.Hour
@@ -147,7 +149,7 @@ func (d *Downloader) getRelays(ctx context.Context) (*internal.Set[domain.RelayA
 	var relays []domain.RelayAddress
 
 	if err := d.transactionProvider.Transact(ctx, func(ctx context.Context, adapters Adapters) error {
-		tmp, err := adapters.Relays.GetRelays(ctx)
+		tmp, err := adapters.Relays.GetRelays(ctx, time.Now().Add(-getRelaysYoungerThan))
 		if err != nil {
 			return errors.Wrap(err, "error getting relays")
 		}
@@ -412,7 +414,7 @@ func (d *RelayDownloader) getPublicKeys(ctx context.Context) (*internal.Set[doma
 	var publicKeys []domain.PublicKey
 
 	if err := d.transactionProvider.Transact(ctx, func(ctx context.Context, adapters Adapters) error {
-		tmp, err := adapters.Relays.GetPublicKeys(ctx, d.address)
+		tmp, err := adapters.Relays.GetPublicKeys(ctx, d.address, time.Now().Add(-getPublicKeysYoungerThan))
 		if err != nil {
 			return errors.Wrap(err, "error getting public keys")
 		}

--- a/service/app/handler_get_public_keys.go
+++ b/service/app/handler_get_public_keys.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"time"
 
 	"github.com/boreq/errors"
 	"github.com/planetary-social/go-notification-service/service/domain"
@@ -27,7 +28,7 @@ func (h *GetPublicKeysHandler) Handle(ctx context.Context, relay domain.RelayAdd
 
 	var result []domain.PublicKey
 	if err := h.transactionProvider.Transact(ctx, func(ctx context.Context, adapters Adapters) error {
-		tmp, err := adapters.Relays.GetPublicKeys(ctx, relay)
+		tmp, err := adapters.Relays.GetPublicKeys(ctx, relay, time.Now().Add(-getPublicKeysYoungerThan))
 		if err != nil {
 			return errors.Wrap(err, "error getting relays")
 		}

--- a/service/app/handler_get_relays.go
+++ b/service/app/handler_get_relays.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"time"
 
 	"github.com/boreq/errors"
 	"github.com/planetary-social/go-notification-service/service/domain"
@@ -27,7 +28,7 @@ func (h *GetRelaysHandler) Handle(ctx context.Context) (addresses []domain.Relay
 
 	var result []domain.RelayAddress
 	if err := h.transactionProvider.Transact(ctx, func(ctx context.Context, adapters Adapters) error {
-		tmp, err := adapters.Relays.GetRelays(ctx)
+		tmp, err := adapters.Relays.GetRelays(ctx, time.Now().Add(-getRelaysYoungerThan))
 		if err != nil {
 			return errors.Wrap(err, "error getting relays")
 		}

--- a/service/app/handler_get_tokens.go
+++ b/service/app/handler_get_tokens.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"time"
 
 	"github.com/boreq/errors"
 	"github.com/planetary-social/go-notification-service/service/domain"
@@ -27,7 +28,7 @@ func (h *GetTokensHandler) Handle(ctx context.Context, publicKey domain.PublicKe
 
 	var result []domain.APNSToken
 	if err := h.transactionProvider.Transact(ctx, func(ctx context.Context, adapters Adapters) error {
-		tmp, err := adapters.PublicKeys.GetAPNSTokens(ctx, publicKey)
+		tmp, err := adapters.PublicKeys.GetAPNSTokens(ctx, publicKey, time.Now().Add(-sendNotificationsToTokensYoungerThan))
 		if err != nil {
 			return errors.Wrap(err, "error getting apns tokens")
 		}

--- a/service/app/handler_process_saved_event.go
+++ b/service/app/handler_process_saved_event.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"time"
 
 	"github.com/boreq/errors"
 	"github.com/planetary-social/go-notification-service/internal"
@@ -14,6 +15,8 @@ const (
 	tagBatchSize                       = 150
 	apnsTokenBatchSize                 = 500
 	onlySaveEventForEventsWithMoreTags = 500
+
+	sendNotificationsToTokensYoungerThan = 6 * 30 * 24 * time.Hour
 )
 
 type ProcessSavedEvent struct {
@@ -126,7 +129,7 @@ func (h *ProcessSavedEventHandler) generateSendAndSaveNotifications(ctx context.
 		mentionToTokens = make(map[domain.PublicKey][]domain.APNSToken) // transactions can run multiple times
 
 		for _, mention := range mentions {
-			tmp, err := adapters.PublicKeys.GetAPNSTokens(ctx, mention)
+			tmp, err := adapters.PublicKeys.GetAPNSTokens(ctx, mention, time.Now().Add(-sendNotificationsToTokensYoungerThan))
 			if err != nil {
 				return errors.Wrap(err, "error getting the token")
 			}


### PR DESCRIPTION
Also we are now running the query in transaction since the emulator apparently supports that?