### PR TITLE
Don't save empty tags

### DIFF
--- a/service/domain/event.go
+++ b/service/domain/event.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/boreq/errors"
 	"github.com/nbd-wtf/go-nostr"
+	"github.com/planetary-social/go-notification-service/internal"
 )
 
 type Event struct {
@@ -100,7 +101,7 @@ func (e Event) Kind() EventKind {
 }
 
 func (e Event) Tags() []EventTag {
-	return e.tags
+	return internal.CopySlice(e.tags)
 }
 
 func (e Event) Content() string {

--- a/service/domain/tags.go
+++ b/service/domain/tags.go
@@ -50,6 +50,10 @@ func (e EventTag) FirstValue() string {
 	return e.tag[1]
 }
 
+func (e EventTag) FirstValueIsAnEmptyString() bool {
+	return e.FirstValue() == ""
+}
+
 func (e EventTag) IsProfile() bool {
 	return e.name == tagProfile
 }


### PR DESCRIPTION
This comes down to a limitation in Firestore, we are trying to put an empty string into a Firestore key.