### PR TITLE
Should check the follower, not the followee

### DIFF
--- a/service/adapters/apns/apns.go
+++ b/service/adapters/apns/apns.go
@@ -133,7 +133,7 @@ func (a *APNS) buildFollowChangeNotification(followChange domain.FollowChange, a
 
 func followChangePayload(followChange domain.FollowChange) ([]byte, error) {
 	alertMessage := ""
-	if strings.HasPrefix(followChange.FriendlyFollowee, "npub") {
+	if strings.HasPrefix(followChange.FriendlyFollower, "npub") {
 		if followChange.ChangeType == "unfollowed" {
 			alertMessage = "You've been unfollowed!"
 		} else {


### PR DESCRIPTION
The conditional to avoid using long npubs was using the the follower for the check, not the followee.