### PR TITLE
Add last_id env suffix

### DIFF
--- a/service/config/config.go
+++ b/service/config/config.go
@@ -11,6 +11,10 @@ type Environment struct {
 	s string
 }
 
+func (e Environment) String() string {
+	return e.s
+}
+
 var (
 	EnvironmentProduction  = Environment{"production"}
 	EnvironmentDevelopment = Environment{"development"}


### PR DESCRIPTION
The dev environment for the notifications service is currently broken, I think it's because of the missing addition in the digital ocean allowed list. Once it fixed it would use the same last id as in production so each env would skip items intended for the other. This adds a suffix to avoid that issue.