### PR TITLE
Add silent notifications

### DIFF
--- a/service/adapters/apns/apns_mock.go
+++ b/service/adapters/apns/apns_mock.go
@@ -41,6 +41,12 @@ func (a *APNSMock) SendFollowChangeNotification(followChange domain.FollowChange
 	return a.SendNotification(notification)
 }
 
+func (a *APNSMock) SendSilentFollowChangeNotification(followChange domain.FollowChangeBatch, token domain.APNSToken) error {
+	notification := notifications.Notification{}
+
+	return a.SendNotification(notification)
+}
+
 func (a *APNSMock) SentNotifications() []notifications.Notification {
 	a.sentNotificationsLock.Lock()
 	defer a.sentNotificationsLock.Unlock()

--- a/service/adapters/apns/apns_test.go
+++ b/service/adapters/apns/apns_test.go
@@ -174,6 +174,34 @@ func TestFollowChangePayload_BatchedFollow_WithNoFriendlyFollower(t *testing.T) 
 
 	require.Equal(t, expectedPayload, actualPayload)
 }
+
+func TestSilentFollowChangePayload_BatchedFollow_WithNoFriendlyFollower(t *testing.T) {
+	pk1, _ := fixtures.PublicKeyAndNpub()
+	pk2, pk2Npub := fixtures.PublicKeyAndNpub()
+	pk3, pk3Npub := fixtures.PublicKeyAndNpub()
+
+	batch := domain.FollowChangeBatch{
+		Followee: pk1,
+		Follows:  []domain.PublicKey{pk2, pk3},
+	}
+
+	payload, err := apns.SilentFollowChangePayload(batch)
+	require.NoError(t, err)
+
+	expectedPayload := map[string]interface{}{
+		"aps": map[string]interface{}{
+			"content-available": float64(1),
+		},
+		"data": map[string]interface{}{
+			"follows": []interface{}{pk2Npub, pk3Npub},
+		},
+	}
+
+	var actualPayload map[string]interface{}
+	err = json.Unmarshal(payload, &actualPayload)
+	require.NoError(t, err)
+	require.Equal(t, expectedPayload, actualPayload)
+}
 func TestFollowChangePayload_Exceeds4096Bytes_With60TotalNpubs(t *testing.T) {
 	pk1, _ := fixtures.PublicKeyAndNpub()
 

--- a/service/app/app.go
+++ b/service/app/app.go
@@ -83,6 +83,7 @@ type Queries struct {
 type APNS interface {
 	SendNotification(notification notifications.Notification) error
 	SendFollowChangeNotification(followChange domain.FollowChangeBatch, apnsToken domain.APNSToken) error
+	SendSilentFollowChangeNotification(followChange domain.FollowChangeBatch, apnsToken domain.APNSToken) error
 }
 
 type EventOrError struct {

--- a/service/app/follow_change_puller.go
+++ b/service/app/follow_change_puller.go
@@ -79,6 +79,15 @@ func (f *FollowChangePuller) Run(ctx context.Context) error {
 						Message("error sending follow change notification")
 					continue
 				}
+
+				if err := f.apns.SendSilentFollowChangeNotification(*followChangeAggregate, token); err != nil {
+					f.logger.Error().
+						WithField("token", token.Hex()).
+						WithField("followee", followChangeAggregate.Followee.Hex()).
+						WithError(err).
+						Message("error sending silent follow change notification")
+					continue
+				}
 			}
 
 			f.counter += 1


### PR DESCRIPTION
Sends a silent notification in parallel to the follow alert so we can update the notifications tab even if the user doesn't tap or ignores the alert.

This is for https://github.com/planetary-social/nos-notification-service-go/issues/74